### PR TITLE
Don't use toLowerCase on params.

### DIFF
--- a/src/router/fileshare.js
+++ b/src/router/fileshare.js
@@ -6,14 +6,7 @@ const User = require('../modules/user.js');
 const fileshare = express.Router();
 
 fileshare.get('/:type/:site/:name', (req, res) => {
-	var file =
-		__dirname +
-		'/../frontend/' +
-		req.params.site.toLowerCase() +
-		'/' +
-		req.params.name.toLowerCase() +
-		'.' +
-		req.params.type.toLowerCase();
+	var file = __dirname + '/../frontend/' + req.params.site + '/' + req.params.name + '.' + req.params.type;
 	console.log(file);
 
 	if (!fs.existsSync(file)) {


### PR DESCRIPTION
Avoid problems where a file is inaccessible because of an upper case letter in a files name or suffix or the name of the folder.